### PR TITLE
Be able to add custom_id and event_payload to email

### DIFF
--- a/lib/bamboo/adapters/mailjet_adapter.ex
+++ b/lib/bamboo/adapters/mailjet_adapter.ex
@@ -172,6 +172,9 @@ defmodule Bamboo.MailjetAdapter do
 
   defp put_custom_id(body, %Email{private: %{mj_custom_id: custom_id}}), do: Map.put(body, "Mj-CustomID", custom_id)
   defp put_custom_id(body, _email), do: body
+  
+  defp put_event_payload(body, %Email{private: %{mj_event_payload: event_payload}}), do: Map.put(body, "Mj-EventPayLoad", event_payload)
+  defp put_event_payload(body, _email), do: body
 
   defp recipients(new_recipients) do
     new_recipients

--- a/lib/bamboo/adapters/mailjet_adapter.ex
+++ b/lib/bamboo/adapters/mailjet_adapter.ex
@@ -190,8 +190,8 @@ defmodule Bamboo.MailjetAdapter do
   defp addresses(new_addresses) do
     new_addresses
     |> Enum.reduce([], fn(address, addresses) ->
-      addresses ++ get_address_output(address)
-    end)
+        addresses ++ get_address_output(address)
+      end)
     |> Enum.join(",")
   end
 

--- a/lib/bamboo/adapters/mailjet_adapter.ex
+++ b/lib/bamboo/adapters/mailjet_adapter.ex
@@ -117,6 +117,8 @@ defmodule Bamboo.MailjetAdapter do
     |> put_template_id(email)
     |> put_template_language(email)
     |> put_vars(email)
+    |> put_custom_id(email)
+    |> put_event_payload(email)
   end
 
   defp put_from(body, %Email{from: address}) when is_binary(address), do: Map.put(body, :fromemail, address)
@@ -168,6 +170,9 @@ defmodule Bamboo.MailjetAdapter do
   defp put_vars(body, %Email{private: %{mj_vars: vars}}), do: Map.put(body, "vars", vars)
   defp put_vars(body, _email), do: body
 
+  defp put_custom_id(body, %Email{private: %{mj_custom_id: custom_id}}), do: Map.put(body, "Mj-CustomID", custom_id)
+  defp put_custom_id(body, _email), do: body
+
   defp recipients(new_recipients) do
     new_recipients
     |> Enum.reduce([], fn(recipient, recipients) ->
@@ -182,8 +187,8 @@ defmodule Bamboo.MailjetAdapter do
   defp addresses(new_addresses) do
     new_addresses
     |> Enum.reduce([], fn(address, addresses) ->
-        addresses ++ get_address_output(address)
-      end)
+      addresses ++ get_address_output(address)
+    end)
     |> Enum.join(",")
   end
 

--- a/lib/bamboo/adapters/mailjet_helper.ex
+++ b/lib/bamboo/adapters/mailjet_helper.ex
@@ -48,4 +48,13 @@ defmodule Bamboo.MailjetHelper do
     vars = Map.get(email.private, :mj_vars, %{})
     Email.put_private(email, :mj_vars, Map.put(vars, key, value))
   end
+
+  @doc """
+  Add a custom id to the email
+
+  this can be used to add a custom id to the email, which will be returned in the mailjet event callback api
+  """
+  def put_custom_id(email, value) do
+    Email.put_private(email, :mj_custom_id, value)
+  end
 end

--- a/lib/bamboo/adapters/mailjet_helper.ex
+++ b/lib/bamboo/adapters/mailjet_helper.ex
@@ -57,4 +57,13 @@ defmodule Bamboo.MailjetHelper do
   def put_custom_id(email, value) do
     Email.put_private(email, :mj_custom_id, value)
   end
+
+  @doc """
+  Add a event payload to the email
+
+  this can be used to add an event payload to the email, which will be returned in the mailjet event callback api
+  """
+  def put_event_payload(email, value) do
+    Email.put_private(email, :mj_event_payload, value)
+  end
 end

--- a/test/lib/bamboo/adapters/mailjet_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailjet_adapter_test.exs
@@ -86,12 +86,12 @@ defmodule Bamboo.MailjetAdapterTest do
 
   test "deliver/2 sends from, html and text body, subject, and headers" do
     email = new_email(
-        from: {"From", "from@foo.com"},
-        subject: "My Subject",
-        text_body: "TEXT BODY",
-        html_body: "HTML BODY",
-      )
-      |> Email.put_header("Reply-To", "reply@foo.com")
+      from: {"From", "from@foo.com"},
+      subject: "My Subject",
+      text_body: "TEXT BODY",
+      html_body: "HTML BODY",
+    )
+    |> Email.put_header("Reply-To", "reply@foo.com")
 
     email |> MailjetAdapter.deliver(@config)
 
@@ -107,10 +107,10 @@ defmodule Bamboo.MailjetAdapterTest do
 
   test "deliver/2 correctly formats TO,CC and BCC" do
     email = new_email(
-        to: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
-        cc: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
-        bcc: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
-      )
+      to: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
+      cc: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
+      bcc: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
+    )
 
     email |> MailjetAdapter.deliver(@config)
 
@@ -125,7 +125,7 @@ defmodule Bamboo.MailjetAdapterTest do
   test "deliver/2 correctly formats Mailjet recipients" do
     email = new_email(
       bcc: [{"user1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
-      )
+    )
 
     email |> MailjetAdapter.deliver(@config)
 

--- a/test/lib/bamboo/adapters/mailjet_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailjet_adapter_test.exs
@@ -86,12 +86,12 @@ defmodule Bamboo.MailjetAdapterTest do
 
   test "deliver/2 sends from, html and text body, subject, and headers" do
     email = new_email(
-      from: {"From", "from@foo.com"},
-      subject: "My Subject",
-      text_body: "TEXT BODY",
-      html_body: "HTML BODY",
-    )
-    |> Email.put_header("Reply-To", "reply@foo.com")
+        from: {"From", "from@foo.com"},
+        subject: "My Subject",
+        text_body: "TEXT BODY",
+        html_body: "HTML BODY",
+      )
+      |> Email.put_header("Reply-To", "reply@foo.com")
 
     email |> MailjetAdapter.deliver(@config)
 
@@ -107,10 +107,10 @@ defmodule Bamboo.MailjetAdapterTest do
 
   test "deliver/2 correctly formats TO,CC and BCC" do
     email = new_email(
-      to: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
-      cc: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
-      bcc: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
-    )
+        to: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
+        cc: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
+        bcc: [{"foo1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
+      )
 
     email |> MailjetAdapter.deliver(@config)
 
@@ -125,7 +125,7 @@ defmodule Bamboo.MailjetAdapterTest do
   test "deliver/2 correctly formats Mailjet recipients" do
     email = new_email(
       bcc: [{"user1", "foo1@bar.com"}, {nil, "foo2@bar.com"}, "foo3@bar.com"],
-    )
+      )
 
     email |> MailjetAdapter.deliver(@config)
 
@@ -164,6 +164,30 @@ defmodule Bamboo.MailjetAdapterTest do
 
     assert_receive {:fake_mailjet, %{params: params}}
     assert params["vars"] == %{"foo1" => "bar1", "foo2" => "bar2"}
+  end
+
+  test "deliver/2 sends with custom id" do
+    new_email(
+      from: {"From", "from@foo.com"},
+      subject: "My Subject"
+    )
+    |> MailjetHelper.put_custom_id("customId1")
+    |> MailjetAdapter.deliver(@config)
+
+    assert_receive {:fake_mailjet, %{params: params}}
+    assert params["Mj-CustomID"] == "customId1"
+  end
+
+  test "deliver/2 sends with event payload" do
+    new_email(
+      from: {"From", "from@foo.com"},
+      subject: "My Subject"
+    )
+    |> MailjetHelper.put_event_payload("customEventPayLoad")
+    |> MailjetAdapter.deliver(@config)
+
+    assert_receive {:fake_mailjet, %{params: params}}
+    assert params["Mj-EventPayLoad"] == "customEventPayLoad"
   end
 
   test "raises if the response is not a success" do


### PR DESCRIPTION
This adds the possibility to add the Mj-CustomID and the Mj-EventPayLoad to an email.

Added this for the events callback api of mailjet, in order to get the CustomID as an ID to use to track the email events for this email.

See:
https://dev.mailjet.com/guides/?shell#event-api-real-time-notifications