### PR TITLE
Made subject optional

### DIFF
--- a/lib/bamboo/adapters/mailjet_adapter.ex
+++ b/lib/bamboo/adapters/mailjet_adapter.ex
@@ -164,6 +164,8 @@ defmodule Bamboo.MailjetAdapter do
     |> put_bcc(email)
   end
 
+  defp put_subject(body, %Email{subject: nil}), do: body
+
   defp put_subject(body, %Email{subject: subject}), do: Map.put(body, :subject, subject)
 
   defp put_html_body(body, %Email{html_body: nil}), do: body


### PR DESCRIPTION
Made subject optional, so that the subject from Mailjet template can be used.

Mailjet throws an error if the `subject` is `null`, instead we have to not send the `subject` key at all.